### PR TITLE
Fix decimal by single/double division

### DIFF
--- a/src/NCalcAsync/Numbers.cs
+++ b/src/NCalcAsync/Numbers.cs
@@ -847,8 +847,8 @@ namespace NCalcAsync
                         case TypeCode.UInt32: return (Decimal)a / (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a / (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a / (UInt64)b;
-                        case TypeCode.Single: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'decimal' and 'float'");
-                        case TypeCode.Double: return Convert.ToDecimal(a) / (Decimal)b;
+                        case TypeCode.Single: return (Decimal)a / Convert.ToDecimal(b);
+                        case TypeCode.Double: return (Decimal)a / Convert.ToDecimal(b);
                         case TypeCode.Decimal: return (Decimal)a / (Decimal)b;
                     }
                     break;

--- a/test/NCalcAsync.Tests/Fixtures.cs
+++ b/test/NCalcAsync.Tests/Fixtures.cs
@@ -445,7 +445,7 @@ namespace NCalcAsync.Tests
                 if (name == "SecretOperation")
                     args.Result = null;
                 Assert.IsTrue(args.HasResult);
-                
+
                 return Task.CompletedTask;
             };
 
@@ -703,6 +703,27 @@ namespace NCalcAsync.Tests
 
             var result2 = Assert.ThrowsException<EvaluationException>(() => Expression.Compile("Format(\"{0:(###) ###-####}\", \"9999999999\")", true));
             Assert.AreEqual("line 1:8 no viable alternative at character '\"'", result2.Message);
+        }
+
+        [TestMethod]
+        public async Task Should_Divide_Decimal_By_Double_Issue_16()
+        {
+            // https://github.com/ncalc/ncalc/issues/16
+
+            var e = new Expression("x / 1.0");
+            e.Parameters["x"] = 1m;
+
+            Assert.AreEqual(1m, await e.EvaluateAsync());
+        }
+
+        [TestMethod]
+        public async Task Should_Divide_Decimal_By_Single()
+        {
+            var e = new Expression("x / y");
+            e.Parameters["x"] = 1m;
+            e.Parameters["y"] = 1f;
+
+            Assert.AreEqual(1m, await e.EvaluateAsync());
         }
     }
 }


### PR DESCRIPTION
This is basically a copy of https://github.com/ncalc/ncalc/pull/31 pull request.
Enables the '/' operator for decimal and single/double values to fix issues like https://github.com/ncalc/ncalc/issues/16.