### PR TITLE
Added EvaluateOptions.CaseInsensitiveComparer

### DIFF
--- a/src/NCalcAsync/EvaluationOption.cs
+++ b/src/NCalcAsync/EvaluationOption.cs
@@ -25,6 +25,11 @@ namespace NCalcAsync
         //
         // Summary:
         //     When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero. 
-        RoundAwayFromZero = 16
+        RoundAwayFromZero = 16,
+        
+        //
+        // Summary:
+        //     Specifies the use of CaseInsensitiveComparer for comparasions.
+        CaseInsensitiveComparer = 32
     }
 }

--- a/test/NCalcAsync.Tests/Fixtures.cs
+++ b/test/NCalcAsync.Tests/Fixtures.cs
@@ -854,6 +854,16 @@ namespace NCalcAsync.Tests
                 Assert.AreEqual(calculatedValue, await expression.EvaluateAsync());
             }
         }
+        
+                
+        [TestMethod]
+        public async Task Should_Use_Case_Insensitive_Comparer_Issue_24()
+        {
+            var eif = new Expression("PageState == 'LIST'", EvaluateOptions.CaseInsensitiveComparer);
+            eif.Parameters["PageState"] = "List";
+
+            Assert.AreEqual(true, await eif.EvaluateAsync());
+        }
     }
 }
 


### PR DESCRIPTION
This closes #24 

I'm using `EvaluateOptions.CaseInsensitiveComparer` because there is no `Comparer` classes to cover all scenarios from the `StringComparer` enum.

Also applied some suggestions from the Rider editor at the codebase.